### PR TITLE
fix: Show homepage url for all owned repositories

### DIFF
--- a/src/lib/github/fetcher.ts
+++ b/src/lib/github/fetcher.ts
@@ -26,12 +26,14 @@ const redactedGitHubRepositoryData = (
         entry.repository.isArchived ||
         entry.repository.isDisabled;
 
+      const ownedByViewer = entry.repository.owner.login === ICY_JOSEPH;
+
       return {
         ...entry,
         repository: {
           ...entry.repository,
           url: hideUrl ? "" : entry.repository.url,
-          homepageUrl: hideUrl ? "" : entry.repository.homepageUrl,
+          homepageUrl: ownedByViewer ? entry.repository.homepageUrl : "",
         },
       };
     });


### PR DESCRIPTION
Minor fix to show homepage urls of owned projects.