### PR TITLE
Markdown loader as file watcher

### DIFF
--- a/loaders/raw-loader.js
+++ b/loaders/raw-loader.js
@@ -1,0 +1,3 @@
+module.exports = function (content) {
+  return `export default ${JSON.stringify(content)}`;
+};

--- a/next.config.ts
+++ b/next.config.ts
@@ -25,8 +25,16 @@ const config: NextConfig = {
     remotePatterns,
   },
   cacheComponents: true,
-  experimental: {
-    browserDebugInfoInTerminal: true,
+  turbopack: {
+    rules: {
+      "*.md": {
+        loaders: ["./loaders/raw-loader.js"],
+        as: "*.js",
+      },
+    },
+  },
+  logging: {
+    browserToTerminal: true,
   },
   headers: async () => [
     {

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "graphql": "16.2.0",
     "graphql-tag": "2.12.6",
     "gray-matter": "4.0.3",
-    "next": "16.2.4",
+    "next": "16.2.6",
     "react": "19.2.4",
     "react-dom": "19.2.4",
     "use-easing": "0.0.9",

--- a/src/app/blog/[slug]/page.tsx
+++ b/src/app/blog/[slug]/page.tsx
@@ -1,7 +1,6 @@
 import { Suspense } from "react";
 
 import type { Metadata } from "next";
-import { cacheLife } from "next/cache";
 import { notFound } from "next/navigation";
 
 import { CountView } from "components/Blog/CountView";
@@ -20,35 +19,38 @@ export const generateMetadata = async (props: {
   params: Promise<{ slug: string }>;
 }): Promise<Metadata> => {
   const params = await props.params;
-  try {
-    const slug = params.slug;
-    const post = await getPostBySlug(slug);
+  const slug = params.slug;
+  const post = await getPostBySlug(slug);
 
+
+  if (!post) {
     return {
       metadataBase: new URL(VERCEL_URL),
-      title: `icyJoseph | ${post.title}`,
-      description: post.summary,
-      openGraph: {
-        url: `/blog/${slug}`,
-        title: `icyJoseph | ${post.title}`,
-        siteName: "icyJoseph",
-        description: post.summary,
-        images: [
-          {
-            url: `/og-image/${slug}`,
-            width: 960,
-            height: 540,
-            alt: `Blog post: ${post.title}`,
-            type: "image/png",
-          },
-        ],
-      },
-    };
-  } catch (_) {
-    return {
       title: "icyJoseph | Not found",
       description: "The resource you were looking for does not exist",
     };
+  }
+
+
+  return {
+    metadataBase: new URL(VERCEL_URL),
+    title: `icyJoseph | ${post.title}`,
+    description: post.summary,
+    openGraph: {
+      url: `/blog/${slug}`,
+      title: `icyJoseph | ${post.title}`,
+      siteName: "icyJoseph",
+      description: post.summary,
+      images: [
+        {
+          url: `/og-image/${slug}`,
+          width: 960,
+          height: 540,
+          alt: `Blog post: ${post.title}`,
+          type: "image/png",
+        },
+      ],
+    },
   }
 };
 
@@ -67,27 +69,25 @@ const intl = new Intl.DateTimeFormat("en-SE", {
 const getPostData = async (
   slug: string
 ): Promise<Post & { content: string; publish_date: number }> => {
-  "use cache";
+  const post = await getPostBySlug(slug);
 
-  try {
-    const post = await getPostBySlug(slug);
+  if (!post) notFound();
 
-    cacheLife("weeks");
+  if (typeof post.content !== "string") {
+    console.log(new Error(`${slug} has no content`))
 
-    if (typeof post.content !== "string")
-      throw new Error(`${slug} has no content`);
-    if (typeof post.publish_date !== "number")
-      throw new Error(`${slug} has no publish date`);
-
-    return {
-      ...post,
-      content: post.content,
-      publish_date: post.publish_date,
-    };
-  } catch (e) {
-    console.log(e);
-    cacheLife({ expire: 0 });
     notFound();
+  }
+  if (typeof post.publish_date !== "number") {
+
+    console.log(new Error(`${slug} has no publish date`))
+    notFound();
+  }
+
+  return {
+    ...post,
+    content: post.content,
+    publish_date: post.publish_date,
   }
 };
 

--- a/src/app/og-image/[slug]/route.tsx
+++ b/src/app/og-image/[slug]/route.tsx
@@ -23,6 +23,10 @@ export async function GET(
 
     const post = await getPostBySlug(slug);
 
+    if (!post) {
+      return new ImageResponse(<ProfileImage />);
+    }
+
     return new ImageResponse(
       (
         <BlogPostImage

--- a/src/lib/posts/db.ts
+++ b/src/lib/posts/db.ts
@@ -8,17 +8,19 @@ import type { SafeParseSuccess } from "zod";
 import { postSchema, postPreviewSchema } from "./parser";
 import type { Post, PostPreview } from "./types";
 
+async function importPost(slug: string): Promise<string> {
+  const mod = await import(`../../../posts/${slug}`);
+  return mod.default;
+}
+
 export const getAllPosts = async (): Promise<PostPreview[]> => {
   "use cache";
   cacheTag("all-posts");
   try {
-    // with extension
     const slugs = await fs.readdir(path.resolve(process.cwd(), "./posts"));
 
     const postsContent = await Promise.all(
-      slugs.map<Promise<string>>((slug) =>
-        fs.readFile(path.resolve(process.cwd(), "./posts", slug), "utf-8")
-      )
+      slugs.map<Promise<string>>((slug) => importPost(slug)),
     );
 
     const posts = postsContent
@@ -36,19 +38,23 @@ export const getAllPosts = async (): Promise<PostPreview[]> => {
   }
 };
 
-export const getPostBySlug = async (slug: string): Promise<Post> => {
+export const getPostBySlug = async (slug: string): Promise<Post | null> => {
   "use cache";
 
-  const postsContent = await fs.readFile(
-    path.resolve(process.cwd(), "./posts", `${slug}.md`),
-    "utf-8"
-  );
+  cacheTag(slug);
 
-  const { content, data } = matter(postsContent);
-  const post = postSchema.parse({ ...data, content });
+  try {
+    const postsContent = await importPost(`${slug}.md`);
 
-  cacheLife("weeks");
-  cacheTag(post.slug);
+    const { content, data } = matter(postsContent);
+    const post = postSchema.parse({ ...data, content });
 
-  return post;
+    cacheLife("weeks");
+    return post;
+  } catch (e) {
+    console.log("Error while getting post by slug", e);
+
+    cacheLife("hours");
+    return null;
+  }
 };

--- a/src/lib/posts/db.ts
+++ b/src/lib/posts/db.ts
@@ -3,7 +3,6 @@ import path from "path";
 
 import matter from "gray-matter";
 import { cacheLife, cacheTag } from "next/cache";
-import type { SafeParseSuccess } from "zod";
 
 import { postSchema, postPreviewSchema } from "./parser";
 import type { Post, PostPreview } from "./types";
@@ -23,12 +22,11 @@ export const getAllPosts = async (): Promise<PostPreview[]> => {
       slugs.map<Promise<string>>((slug) => importPost(slug)),
     );
 
-    const posts = postsContent
-      .map((content) => matter(content))
-      .map(({ data, content }) => ({ ...data, content }))
-      .map((post) => postPreviewSchema.safeParse(post))
-      .filter((result): result is SafeParseSuccess<Post> => result.success)
-      .map(({ data }) => data);
+    const posts = postsContent.flatMap((content) => {
+      const { data, content: body } = matter(content);
+      const result = postPreviewSchema.safeParse({ ...data, content: body });
+      return result.success ? [result.data] : [];
+    });
 
     return posts;
   } catch (e) {

--- a/src/types.d.ts
+++ b/src/types.d.ts
@@ -1,3 +1,8 @@
+declare module "*.md" {
+  const content: string;
+  export default content;
+}
+
 declare namespace NodeJS {
   interface ProcessEnv {
     BLOG_VIEWS_URL: string;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,7 +14,7 @@
     "downlevelIteration": true,
     "esModuleInterop": true,
     "module": "esnext",
-    "moduleResolution": "node",
+    "moduleResolution": "bundler",
     "moduleDetection": "force",
     "resolveJsonModule": true,
     "isolatedModules": true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1263,10 +1263,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/env@npm:16.2.4":
-  version: 16.2.4
-  resolution: "@next/env@npm:16.2.4"
-  checksum: 10c0/4bf41f0da7cc97ca2a2f2b7f3fc81e14aba2afc280d32163b134b8f642b315fbabb5d9c224a783d8e759bbc73eedfc9acd048e772950395aa1e6290dd386d209
+"@next/env@npm:16.2.6":
+  version: 16.2.6
+  resolution: "@next/env@npm:16.2.6"
+  checksum: 10c0/466722ce30a9561d29c08a7ba78091a47fef3644f422d04751c7124a24457ffe11eb25bb6c59c1e1d57735d9c68c58d185cc19ea58befd7a9c5b81dc05ca550d
   languageName: node
   linkType: hard
 
@@ -1279,58 +1279,58 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-arm64@npm:16.2.4":
-  version: 16.2.4
-  resolution: "@next/swc-darwin-arm64@npm:16.2.4"
+"@next/swc-darwin-arm64@npm:16.2.6":
+  version: 16.2.6
+  resolution: "@next/swc-darwin-arm64@npm:16.2.6"
   conditions: os=darwin & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-darwin-x64@npm:16.2.4":
-  version: 16.2.4
-  resolution: "@next/swc-darwin-x64@npm:16.2.4"
+"@next/swc-darwin-x64@npm:16.2.6":
+  version: 16.2.6
+  resolution: "@next/swc-darwin-x64@npm:16.2.6"
   conditions: os=darwin & cpu=x64
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-gnu@npm:16.2.4":
-  version: 16.2.4
-  resolution: "@next/swc-linux-arm64-gnu@npm:16.2.4"
+"@next/swc-linux-arm64-gnu@npm:16.2.6":
+  version: 16.2.6
+  resolution: "@next/swc-linux-arm64-gnu@npm:16.2.6"
   conditions: os=linux & cpu=arm64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-arm64-musl@npm:16.2.4":
-  version: 16.2.4
-  resolution: "@next/swc-linux-arm64-musl@npm:16.2.4"
+"@next/swc-linux-arm64-musl@npm:16.2.6":
+  version: 16.2.6
+  resolution: "@next/swc-linux-arm64-musl@npm:16.2.6"
   conditions: os=linux & cpu=arm64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-gnu@npm:16.2.4":
-  version: 16.2.4
-  resolution: "@next/swc-linux-x64-gnu@npm:16.2.4"
+"@next/swc-linux-x64-gnu@npm:16.2.6":
+  version: 16.2.6
+  resolution: "@next/swc-linux-x64-gnu@npm:16.2.6"
   conditions: os=linux & cpu=x64 & libc=glibc
   languageName: node
   linkType: hard
 
-"@next/swc-linux-x64-musl@npm:16.2.4":
-  version: 16.2.4
-  resolution: "@next/swc-linux-x64-musl@npm:16.2.4"
+"@next/swc-linux-x64-musl@npm:16.2.6":
+  version: 16.2.6
+  resolution: "@next/swc-linux-x64-musl@npm:16.2.6"
   conditions: os=linux & cpu=x64 & libc=musl
   languageName: node
   linkType: hard
 
-"@next/swc-win32-arm64-msvc@npm:16.2.4":
-  version: 16.2.4
-  resolution: "@next/swc-win32-arm64-msvc@npm:16.2.4"
+"@next/swc-win32-arm64-msvc@npm:16.2.6":
+  version: 16.2.6
+  resolution: "@next/swc-win32-arm64-msvc@npm:16.2.6"
   conditions: os=win32 & cpu=arm64
   languageName: node
   linkType: hard
 
-"@next/swc-win32-x64-msvc@npm:16.2.4":
-  version: 16.2.4
-  resolution: "@next/swc-win32-x64-msvc@npm:16.2.4"
+"@next/swc-win32-x64-msvc@npm:16.2.6":
+  version: 16.2.6
+  resolution: "@next/swc-win32-x64-msvc@npm:16.2.6"
   conditions: os=win32 & cpu=x64
   languageName: node
   linkType: hard
@@ -5319,7 +5319,7 @@ __metadata:
     jest-environment-jsdom: "npm:29.5.0"
     jsdom-testing-mocks: "npm:1.7.0"
     msw: "npm:1.1.0"
-    next: "npm:16.2.4"
+    next: "npm:16.2.6"
     postcss: "npm:8.4.22"
     react: "npm:19.2.4"
     react-dom: "npm:19.2.4"
@@ -7639,19 +7639,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"next@npm:16.2.4":
-  version: 16.2.4
-  resolution: "next@npm:16.2.4"
+"next@npm:16.2.6":
+  version: 16.2.6
+  resolution: "next@npm:16.2.6"
   dependencies:
-    "@next/env": "npm:16.2.4"
-    "@next/swc-darwin-arm64": "npm:16.2.4"
-    "@next/swc-darwin-x64": "npm:16.2.4"
-    "@next/swc-linux-arm64-gnu": "npm:16.2.4"
-    "@next/swc-linux-arm64-musl": "npm:16.2.4"
-    "@next/swc-linux-x64-gnu": "npm:16.2.4"
-    "@next/swc-linux-x64-musl": "npm:16.2.4"
-    "@next/swc-win32-arm64-msvc": "npm:16.2.4"
-    "@next/swc-win32-x64-msvc": "npm:16.2.4"
+    "@next/env": "npm:16.2.6"
+    "@next/swc-darwin-arm64": "npm:16.2.6"
+    "@next/swc-darwin-x64": "npm:16.2.6"
+    "@next/swc-linux-arm64-gnu": "npm:16.2.6"
+    "@next/swc-linux-arm64-musl": "npm:16.2.6"
+    "@next/swc-linux-x64-gnu": "npm:16.2.6"
+    "@next/swc-linux-x64-musl": "npm:16.2.6"
+    "@next/swc-win32-arm64-msvc": "npm:16.2.6"
+    "@next/swc-win32-x64-msvc": "npm:16.2.6"
     "@swc/helpers": "npm:0.5.15"
     baseline-browser-mapping: "npm:^2.9.19"
     caniuse-lite: "npm:^1.0.30001579"
@@ -7695,7 +7695,7 @@ __metadata:
       optional: true
   bin:
     next: dist/bin/next
-  checksum: 10c0/81dc1ef30141891dc5cc999a0a6210c68305b585b3a7508799767572a9fb7e4c7dcb5a50f5fa3fabadf6a46c2273405360b1d6f17f89edd891da1746ae31c186
+  checksum: 10c0/3572071eb0e8051c3b007224dcf642037ce27a2f4b75c45f7e0fe7f2343e98e66604ce8696dde56ecd72963900d330d3a3af0f068f34cfc67520180263effa5f
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Implement a loader to watch markdown files via Turbopack. This gives markdown HMR via Turbopack, without a userland file watcher.

Also lower `use cache` into `getPostBySlug`.

Finally, join a map+filter combo into a single `flatMap`.